### PR TITLE
Re-ordering Observer kwargs

### DIFF
--- a/astroplan/core.py
+++ b/astroplan/core.py
@@ -81,7 +81,7 @@ class Observer(object):
     TODO: write this docstring
     """
     @u.quantity_input(elevation=u.m)
-    def __init__(self, location=None, name=None, timezone='UTC', latitude=None,
+    def __init__(self, location=None, timezone='UTC', name=None, latitude=None,
                  longitude=None, elevation=0*u.m, pressure=None,
                  relative_humidity=None, temperature=None, description=None):
         """

--- a/astroplan/core.py
+++ b/astroplan/core.py
@@ -81,8 +81,8 @@ class Observer(object):
     TODO: write this docstring
     """
     @u.quantity_input(elevation=u.m)
-    def __init__(self, name=None, location=None, latitude=None, longitude=None,
-                 elevation=0*u.m, timezone='UTC', pressure=None,
+    def __init__(self, location=None, name=None, timezone='UTC', latitude=None,
+                 longitude=None, elevation=0*u.m, pressure=None,
                  relative_humidity=None, temperature=None, description=None):
         """
         Parameters


### PR DESCRIPTION
Here's a really tiny PR to re-order the kwargs in `Observer` so you can initialize `Observer`s faster. In all of my examples I've had to use the `location` kwarg whenever initializing an example observatory, like this:
```python
obs = Observer(location=EarthLocation(...))
```
Often the observatory name isn't important, so I've reordered the kwargs to reflect the order of importance in the calculations (location, timezone, name), so you don't need to write the kwarg names each time, like this:
```python
obs = Observer(EarthLocation(...))
obs = Observer(EarthLocation(...), 'US/Hawaii')
obs = Observer(EarthLocation(...), 'US/Hawaii', 'Subaru')
```