### PR TITLE
Remove dummy test function

### DIFF
--- a/astroplan/tests/test_utils.py
+++ b/astroplan/tests/test_utils.py
@@ -1,11 +1,3 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
-from astropy.time import Time
-from ..utils import observe
-
-
-def test_observe():
-    time, pos = observe()
-    millenium = Time('2000-01-01T00:00:00')
-    assert time > millenium

--- a/astroplan/utils.py
+++ b/astroplan/utils.py
@@ -1,17 +1,10 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
-from astropy.time import Time
-from astropy.coordinates import get_sun
 
-__all__ = ['observe']
+__all__ = []
 
-
-def observe():
-    """Dummy function to check if tests / docs work.
-    """
-    time = Time.now()
-    pos = get_sun(time)
-    print('Current time: {}'.format(time))
-    print('Sun location: {}'.format(pos))
-    return time, pos
+# Nothing here for now.
+# We could remove this file, but usually sooner or later there
+# will be some `utils` helper functions that could go here,
+# so keeping it for now.

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -5,11 +5,3 @@ Getting Started
 ***************
 
 To be written ...
-
-For now all we have is a single dummy function and test:
-
-.. doctest-skip::
-
-    >>> import astroplan
-    >>> time, pos = astroplan.observe()
-    >>> astroplan.test()


### PR DESCRIPTION
At the start of the project I added a single dummy function and test.
Now that we have real code and tests, it should be removed, which is done in this PR.

@eteq – Can you please have a look and merge if it's OK and travis-ci passes?