### PR TITLE
is_night convenience method

### DIFF
--- a/astroplan/core.py
+++ b/astroplan/core.py
@@ -1166,6 +1166,34 @@ class Observer(object):
         else:
             return observable, altaz
 
+    @u.quantity_input(horizon=u.deg)
+    def is_night(self, time, horizon=0*u.deg, obswl=None):
+        """
+        Is the Sun below ``horizon`` at ``time``?
+
+        Parameters
+        ----------
+        time : `~astropy.time.Time` or other (see below)
+            Time of observation. This will be passed in as the first argument to
+            the `~astropy.time.Time` initializer, so it can be anything that
+            `~astropy.time.Time` will accept (including a `~astropy.time.Time`
+            object)
+
+        horizon : `~astropy.units.Quantity` (optional), default = zero degrees
+            Degrees above/below actual horizon to use
+            for calculating day/night (i.e.,
+            -6 deg horizon = civil twilight, etc.)
+
+        obswl : `~astropy.units.Quantity` (optional)
+            Wavelength of the observation used in the calculation.
+        """
+        if not isinstance(time, Time):
+            time = Time(time)
+
+        solar_altitude = self.altaz(time, target=get_sun(time), obswl=obswl).alt
+        sun_below_horizon = solar_altitude < horizon
+        return sun_below_horizon
+
 class Target(object):
     """
     This is an abstract base class -- you can't instantiate

--- a/astroplan/core.py
+++ b/astroplan/core.py
@@ -1188,6 +1188,7 @@ class Observer(object):
             Wavelength of the observation used in the calculation
 
         Returns
+        -------
         sun_below_horizon : bool
             `True` if sun is below ``horizon`` at ``time``, else `False`.
         """

--- a/astroplan/core.py
+++ b/astroplan/core.py
@@ -1196,8 +1196,7 @@ class Observer(object):
             time = Time(time)
 
         solar_altitude = self.altaz(time, target=get_sun(time), obswl=obswl).alt
-        sun_below_horizon = solar_altitude < horizon
-        return sun_below_horizon
+        return solar_altitude < horizon
 
 class Target(object):
     """

--- a/astroplan/core.py
+++ b/astroplan/core.py
@@ -1185,7 +1185,11 @@ class Observer(object):
             -6 deg horizon = civil twilight, etc.)
 
         obswl : `~astropy.units.Quantity` (optional)
-            Wavelength of the observation used in the calculation.
+            Wavelength of the observation used in the calculation
+
+        Returns
+        sun_below_horizon : bool
+            `True` if sun is below ``horizon`` at ``time``, else `False`.
         """
         if not isinstance(time, Time):
             time = Time(time)

--- a/astroplan/tests/test_core.py
+++ b/astroplan/tests/test_core.py
@@ -12,6 +12,7 @@ import datetime
 import unittest
 
 from ..core import FixedTarget, Observer
+from ..sites import get_site
 from ..exceptions import TargetAlwaysUpWarning, TargetNeverUpWarning
 
 def test_Observer_constructor_location():
@@ -770,6 +771,19 @@ def test_timezone_convenience_methods():
     dts = obs.astropy_time_to_datetime(times)
     naive_dts = list(map(lambda t: t.replace(tzinfo=None), dts))
     assert all(naive_dts == times_dt_ndarray - datetime.timedelta(hours=4))
+
+def test_is_night():
+    lco = Observer(location=get_site('lco')) # Las Campanas
+    aao = Observer(location=get_site('aao')) # Sydney, Australia
+    vbo = Observer(location=get_site('vbo')) # India
+
+    time1 = Time('2015-07-28 17:00:00')
+    nights1 = [observer.is_night(time1) for observer in [lco, aao, vbo]]
+    assert np.all(nights1 == [False, True, True])
+
+    time2 = Time('2015-07-28 02:00:00')
+    nights2 = [observer.is_night(time2) for observer in [lco, aao, vbo]]
+    assert np.all(nights2 == [True, False, False])
 
 class TestExceptions(unittest.TestCase):
     def test_rise_set_transit_which(self):


### PR DESCRIPTION
Enhancement: `observer.is_night(time, [horizon])`

Is the sun below specified `horizon` at `time` for an `Observer`? This is a method I was writing for myself when coding up a use case, so I stuck it into `Observer` for everyone.