### PR TITLE
Adding Observer.at_site class method

### DIFF
--- a/astroplan/core.py
+++ b/astroplan/core.py
@@ -22,8 +22,8 @@ iers.IERS.iers_table = iers.IERS_A.open(download_file(iers.IERS_A_URL,
 
 from astropy.extern.six import string_types
 from .exceptions import TargetNeverUpWarning, TargetAlwaysUpWarning
+from .sites import get_site
 import warnings
-
 
 from abc import ABCMeta, abstractmethod
 
@@ -156,6 +156,28 @@ class Observer(object):
         else:
             raise TypeError('timezone keyword should be a string, or an '
                             'instance of datetime.tzinfo')
+
+    @classmethod
+    def at_site(cls, site_name, **kwargs):
+        """
+        Initialize an `~astroplan.core.Observer` object with a site name.
+
+        Parameters
+        ----------
+        site_name : str
+            Observatory name, must be resolvable with
+            `~astroplan.sites.get_site`
+
+        Returns
+        -------
+        `~astroplan.core.Observer`
+            Observer object.
+        """
+        name = kwargs.pop('name', site_name)
+        if 'location' in kwargs:
+            raise ValueError("Location kwarg should not be used if "
+                             "initializing an Observer with Observer.at_site()")
+        return cls(location=get_site(site_name), name=name, **kwargs)
 
     def astropy_time_to_datetime(self, astropy_time):
         """

--- a/astroplan/core.py
+++ b/astroplan/core.py
@@ -162,47 +162,15 @@ class Observer(object):
         """
         Initialize an `~astroplan.core.Observer` object with a site name.
 
+        Extra keyword arguments are passed to the `~astroplan.core.Observer`
+        constructor (see `~astroplan.core.Observer` for available keyword
+        arguments).
+
         Parameters
         ----------
         site_name : str
             Observatory name, must be resolvable with
             `~astroplan.sites.get_site`.
-
-        name : str
-            A short name for the telescope, observatory or location. If no name
-            is given, ``site_name`` will be used as the name.
-
-        location : `~astropy.coordinates.EarthLocation`
-            The location (latitude, longitude, elevation) of the observatory.
-
-        longitude : float, str, `~astropy.units.Quantity` (optional)
-            The longitude of the observing location. Should be valid input for
-            initializing a `~astropy.coordinates.Longitude` object.
-
-        latitude : float, str, `~astropy.units.Quantity` (optional)
-            The latitude of the observing location. Should be valid input for
-            initializing a `~astropy.coordinates.Latitude` object.
-
-        elevation : `~astropy.units.Quantity` (optional), default = 0 meters
-            The elevation of the observing location, with respect to sea
-            level. Defaults to sea level.
-
-        pressure : `~astropy.units.Quantity` (optional)
-            The ambient pressure. Defaults to zero (i.e. no atmosphere).
-
-        relative_humidity : float (optional)
-            The ambient relative humidity.
-
-        temperature : `~astropy.units.Quantity` (optional)
-            The ambient temperature.
-
-        timezone : str or `datetime.tzinfo` (optional)
-            The local timezone to assume. If a string, it will be passed through
-            `pytz.timezone()` to produce the timezone object.
-
-        description : str (optional)
-            A short description of the telescope, observatory or observing
-            location.
 
         Returns
         -------

--- a/astroplan/core.py
+++ b/astroplan/core.py
@@ -166,12 +166,57 @@ class Observer(object):
         ----------
         site_name : str
             Observatory name, must be resolvable with
-            `~astroplan.sites.get_site`
+            `~astroplan.sites.get_site`.
+
+        name : str
+            A short name for the telescope, observatory or location. If no name
+            is given, ``site_name`` will be used as the name.
+
+        location : `~astropy.coordinates.EarthLocation`
+            The location (latitude, longitude, elevation) of the observatory.
+
+        longitude : float, str, `~astropy.units.Quantity` (optional)
+            The longitude of the observing location. Should be valid input for
+            initializing a `~astropy.coordinates.Longitude` object.
+
+        latitude : float, str, `~astropy.units.Quantity` (optional)
+            The latitude of the observing location. Should be valid input for
+            initializing a `~astropy.coordinates.Latitude` object.
+
+        elevation : `~astropy.units.Quantity` (optional), default = 0 meters
+            The elevation of the observing location, with respect to sea
+            level. Defaults to sea level.
+
+        pressure : `~astropy.units.Quantity` (optional)
+            The ambient pressure. Defaults to zero (i.e. no atmosphere).
+
+        relative_humidity : float (optional)
+            The ambient relative humidity.
+
+        temperature : `~astropy.units.Quantity` (optional)
+            The ambient temperature.
+
+        timezone : str or `datetime.tzinfo` (optional)
+            The local timezone to assume. If a string, it will be passed through
+            `pytz.timezone()` to produce the timezone object.
+
+        description : str (optional)
+            A short description of the telescope, observatory or observing
+            location.
 
         Returns
         -------
         `~astroplan.core.Observer`
             Observer object.
+
+        Examples
+        --------
+        Initialize an observer at Kitt Peak National Observatory:
+
+        >>> from astroplan import Observer
+        >>> import astropy.units as u
+        >>> kpno_generic = Observer.at_site('kpno')
+        >>> kpno_today = Observer.at_site('kpno', pressure=1*u.bar, temperature=0*u.deg_C)
         """
         name = kwargs.pop('name', site_name)
         if 'location' in kwargs:

--- a/astroplan/tests/test_sites.py
+++ b/astroplan/tests/test_sites.py
@@ -1,6 +1,7 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 from ..sites import get_site, add_site
+from ..core import Observer
 from astropy.tests.helper import assert_quantity_allclose
 from astropy.coordinates import Latitude, Longitude, EarthLocation
 import astropy.units as u
@@ -32,6 +33,12 @@ def test_add_site():
     add_site(new_site_name, new_site_location)
     retrieved_location = get_site(new_site_name)
     assert retrieved_location == new_site_location
+
+def test_Observer_classmethod():
+    site_name = 'kpno'
+    kpno = Observer.at_site(site_name)
+    assert kpno.location == get_site(site_name)
+    assert kpno.name == site_name
 
 class TestExceptions(unittest.TestCase):
     def test_bad_site(self):

--- a/astroplan/tests/test_sites.py
+++ b/astroplan/tests/test_sites.py
@@ -36,9 +36,14 @@ def test_add_site():
 
 def test_Observer_classmethod():
     site_name = 'kpno'
-    kpno = Observer.at_site(site_name)
+    pressure = 1*u.bar
+    temperature = 0*u.deg_C
+    kpno = Observer.at_site(site_name, pressure=pressure,
+                            temperature=temperature)
     assert kpno.location == get_site(site_name)
     assert kpno.name == site_name
+    assert kpno.temperature == temperature
+    assert kpno.pressure == pressure
 
 class TestExceptions(unittest.TestCase):
     def test_bad_site(self):


### PR DESCRIPTION
Making it easier to initialize an `Observer`object at a site via the `sites` module, as per a conversation with @eteq on Slack. 

Now to initialize an observer at Kitt Peak, for example:
```python
from astroplan import Observer
kpno = Observer.at_site("kpno")
```