### PR TITLE
__repr__'s for Observer, FixedTarget

### DIFF
--- a/astroplan/core.py
+++ b/astroplan/core.py
@@ -158,6 +158,24 @@ class Observer(object):
             raise TypeError('timezone keyword should be a string, or an '
                             'instance of datetime.tzinfo')
 
+    def __repr__(self):
+        class_name = self.__class__.__name__
+        attr_names = ['name', 'location', 'timezone', 'pressure', 'temperature',
+                      'relative_humidity']
+        attr_values = [getattr(self, attr) for attr in attr_names]
+        attributes_strings = []
+        for name, value in zip(attr_names, attr_values):
+            if value is not None:
+                if name == 'location':
+                    formatted_loc = ["{} {}".format(i.value, i.unit)
+                                     for i in value.to_geodetic()]
+                    attributes_strings.append(
+                        "{} (lon, lat, el)=({})".format(name,
+                                                        ", ".join(formatted_loc)))
+                else:
+                    attributes_strings.append("{}={}".format(name, repr(value)))
+        return "<{}: {}>".format(class_name, ",\n    ".join(attributes_strings))
+
     @classmethod
     def at_site(cls, site_name, **kwargs):
         """

--- a/astroplan/core.py
+++ b/astroplan/core.py
@@ -1411,14 +1411,8 @@ class FixedTarget(Target):
 
     def __repr__(self):
         class_name = self.__class__.__name__
-        attr_names = ['name', 'coord']
-        attr_values = [getattr(self, attr) for attr in attr_names]
-        attributes_strings = []
-        for name, value in zip(attr_names, attr_values):
-            if value is not None:
-                attributes_strings.append("{}={}".format(name, repr(value)))
-        return "<{}: {}>".format(class_name, ",\n    ".join(attributes_strings))
-
+        fmt_coord = repr(self.coord).replace('\n   ', '')[1:-1]
+        return '<{} "{}" at {}>'.format(class_name, self.name, fmt_coord)
 
 class NonFixedTarget(Target):
     """

--- a/astroplan/core.py
+++ b/astroplan/core.py
@@ -166,6 +166,7 @@ class Observer(object):
         attributes_strings = []
         for name, value in zip(attr_names, attr_values):
             if value is not None:
+                # Format location for easy readability
                 if name == 'location':
                     formatted_loc = ["{} {}".format(i.value, i.unit)
                                      for i in value.to_geodetic()]
@@ -1407,6 +1408,17 @@ class FixedTarget(Target):
         if name is None:
             name = query_name
         return cls(SkyCoord.from_name(query_name), name=name, **kwargs)
+
+    def __repr__(self):
+        class_name = self.__class__.__name__
+        attr_names = ['name', 'coord']
+        attr_values = [getattr(self, attr) for attr in attr_names]
+        attributes_strings = []
+        for name, value in zip(attr_names, attr_values):
+            if value is not None:
+                attributes_strings.append("{}={}".format(name, repr(value)))
+        return "<{}: {}>".format(class_name, ",\n    ".join(attributes_strings))
+
 
 class NonFixedTarget(Target):
     """

--- a/astroplan/core.py
+++ b/astroplan/core.py
@@ -159,6 +159,19 @@ class Observer(object):
                             'instance of datetime.tzinfo')
 
     def __repr__(self):
+        """
+        String representation of the `~astroplan.Observer` object.
+
+        Examples
+        --------
+
+        >>> from astroplan import Observer
+        >>> keck = Observer.at_site("Keck", timezone="US/Hawaii")
+        >>> print(keck)                                    # doctest: +FLOAT_CMP
+        <Observer: name='Keck',
+            location (lon, lat, el)=(-155.478333333 deg, 19.8283333333 deg, 4160.0 m),
+            timezone=<DstTzInfo 'US/Hawaii' LMT-1 day, 13:29:00 STD>>
+        """
         class_name = self.__class__.__name__
         attr_names = ['name', 'location', 'timezone', 'pressure', 'temperature',
                       'relative_humidity']
@@ -174,7 +187,11 @@ class Observer(object):
                         "{} (lon, lat, el)=({})".format(name,
                                                         ", ".join(formatted_loc)))
                 else:
-                    attributes_strings.append("{}={}".format(name, repr(value)))
+                    if name != 'name':
+                        value = repr(value)
+                    else:
+                        value = "'{}'".format(value)
+                    attributes_strings.append("{}={}".format(name, value))
         return "<{}: {}>".format(class_name, ",\n    ".join(attributes_strings))
 
     @classmethod
@@ -1410,6 +1427,21 @@ class FixedTarget(Target):
         return cls(SkyCoord.from_name(query_name), name=name, **kwargs)
 
     def __repr__(self):
+        """
+        String representation of `~astroplan.FixedTarget`.
+
+        Examples
+        --------
+        Show string representation of a `~astroplan.FixedTarget` for Vega:
+
+        >>> from astroplan import FixedTarget
+        >>> from astroplan import FixedTarget
+        >>> from astropy.coordinates import SkyCoord
+        >>> vega_coord = SkyCoord(ra='279.23473479d', dec='38.78368896d')
+        >>> vega = FixedTarget(coord=vega_coord, name="Vega")
+        >>> print(vega)                             # doctest: +FLOAT_CMP
+        <FixedTarget "Vega" at SkyCoord (ICRS): (ra, dec) in deg (279.23473479, 38.78368894)>
+        """
         class_name = self.__class__.__name__
         fmt_coord = repr(self.coord).replace('\n   ', '')[1:-1]
         return '<{} "{}" at {}>'.format(class_name, self.name, fmt_coord)

--- a/astroplan/tests/test_core.py
+++ b/astroplan/tests/test_core.py
@@ -60,6 +60,19 @@ def test_FixedTarget_from_name():
     # Make sure separation is small
     assert polaris_from_name.coord.separation(polaris_from_SIMBAD) < 1*u.arcsec
 
+def test_fixedtarget_repr():
+    vega_coords = SkyCoord('18h36m56.33635s', '+38d47m01.2802s')
+    vega = FixedTarget(coord=vega_coords, name="Vega")
+    assert repr(vega) == ('<FixedTarget "Vega" at SkyCoord (ICRS): (ra, dec) '
+                          'in deg (279.23473479, 38.78368894)>')
+
+def test_observer_repr():
+    obs = Observer.at_site("Keck", timezone="US/Hawaii")
+    assert repr(obs) == ("<Observer: name='Keck',\n    location (lon, lat, el)="
+                         "(-155.478333333 deg, 19.8283333333 deg, 4160.0 m),\n "
+                         "   timezone=<DstTzInfo 'US/Hawaii' LMT-1 day, "
+                         "13:29:00 STD>>")
+
 def test_Observer_altaz():
     '''
     Check that the altitude/azimuth computed by `Observer.altaz` is similar

--- a/astroplan/tests/test_core.py
+++ b/astroplan/tests/test_core.py
@@ -60,19 +60,6 @@ def test_FixedTarget_from_name():
     # Make sure separation is small
     assert polaris_from_name.coord.separation(polaris_from_SIMBAD) < 1*u.arcsec
 
-def test_fixedtarget_repr():
-    vega_coords = SkyCoord('18h36m56.33635s', '+38d47m01.2802s')
-    vega = FixedTarget(coord=vega_coords, name="Vega")
-    assert repr(vega) == ('<FixedTarget "Vega" at SkyCoord (ICRS): (ra, dec) '
-                          'in deg (279.23473479, 38.78368894)>')
-
-def test_observer_repr():
-    obs = Observer.at_site("Keck", timezone="US/Hawaii")
-    assert repr(obs) == ("<Observer: name='Keck',\n    location (lon, lat, el)="
-                         "(-155.478333333 deg, 19.8283333333 deg, 4160.0 m),\n "
-                         "   timezone=<DstTzInfo 'US/Hawaii' LMT-1 day, "
-                         "13:29:00 STD>>")
-
 def test_Observer_altaz():
     '''
     Check that the altitude/azimuth computed by `Observer.altaz` is similar


### PR DESCRIPTION
It's time to make some informative `__repr__` methods for `Observer` and `FixedTarget`. Here's what I've done to start the conversation: 

```python
>>> from astroplan import Observer, FixedTarget
>>> keck = Observer.at_site("Keck", timezone="US/Hawaii")
>>> print(keck)
<Observer: name=u'Keck',
    location (lon, lat, el)=(-155.478333333 deg, 19.8283333333 deg, 4160.0 m),
    timezone=<DstTzInfo 'US/Hawaii' LMT-1 day, 13:29:00 STD>>

>>> polaris = FixedTarget.from_name('Polaris')
>>> print(polaris)
<FixedTarget: name=u'Polaris',
    coord=<SkyCoord (ICRS): (ra, dec) in deg
    (37.95456067, 89.26410897)>>
```
Thoughts and feelings, @astroplanners/astroplanners-contributors?