### PR TITLE
Add Subaru to observatories.json, new site-constructing method

### DIFF
--- a/astroplan/data/observatories.json
+++ b/astroplan/data/observatories.json
@@ -1,7 +1,6 @@
 {
     "BAO": {
         "aliases": [
-            "BAO", 
             "Beijing XingLong Observatory"
         ], 
         "elevation_meters": 950, 
@@ -12,9 +11,8 @@
     }, 
     "NOV": {
         "aliases": [
-            "National Observatory of Venezuela", 
-            "NOV"
-        ], 
+            "National Observatory of Venezuela"
+        ],
         "elevation_meters": 3610, 
         "latitude": "8d47m24s", 
         "longitude": "289d08m00s", 
@@ -23,7 +21,6 @@
     }, 
     "Palomar": {
         "aliases": [
-            "Palomar", 
             "Hale Telescope"
         ], 
         "elevation_meters": 1706, 
@@ -34,7 +31,6 @@
     }, 
     "aao": {
         "aliases": [
-            "AAO", 
             "Anglo-Australian Observatory"
         ], 
         "elevation_meters": 1164, 
@@ -45,7 +41,6 @@
     }, 
     "apo": {
         "aliases": [
-            "APO", 
             "Apache Point Observatory", 
             "Apache Point"
         ], 
@@ -57,8 +52,7 @@
     }, 
     "bmo": {
         "aliases": [
-            "Black Moshannon Observatory", 
-            "BMO"
+            "Black Moshannon Observatory"
         ], 
         "elevation_meters": 738, 
         "latitude": "40d55m18s", 
@@ -68,8 +62,7 @@
     }, 
     "cfht": {
         "aliases": [
-            "Canada-France-Hawaii Telescope", 
-            "CFHT"
+            "Canada-France-Hawaii Telescope"
         ], 
         "elevation_meters": 4215, 
         "latitude": "19d49m36s", 
@@ -80,7 +73,6 @@
     "ctio": {
         "aliases": [
             "Cerro Tololo Interamerican Observatory", 
-            "CTIO", 
             "Cerro Tololo"
         ], 
         "elevation_meters": 2215, 
@@ -91,7 +83,6 @@
     }, 
     "dao": {
         "aliases": [
-            "DAO", 
             "Dominion Astrophysical Observatory"
         ], 
         "elevation_meters": 229, 
@@ -102,7 +93,6 @@
     }, 
     "ekar": {
         "aliases": [
-            "ekar", 
             "Mt. Ekar 182 cm. Telescope"
         ], 
         "elevation_meters": 1413, 
@@ -113,9 +103,8 @@
     }, 
     "eso": {
         "aliases": [
-            "European Southern Observatory", 
-            "ESO"
-        ], 
+            "European Southern Observatory"
+        ],
         "elevation_meters": 2347, 
         "latitude": "-29d15m24s", 
         "longitude": "289d16m12s", 
@@ -125,9 +114,8 @@
     "flwo": {
         "aliases": [
             "Whipple", 
-            "Whipple Observatory", 
-            "FLWO"
-        ], 
+            "Whipple Observatory"
+        ],
         "elevation_meters": 2320, 
         "latitude": "31d40m51.4s", 
         "longitude": "249d07m21s", 
@@ -136,8 +124,7 @@
     }, 
     "keck": {
         "aliases": [
-            "keck", 
-            "W. M. Keck Observatory", 
+            "W. M. Keck Observatory",
             "Keck Observatory"
         ], 
         "elevation_meters": 4160, 
@@ -149,7 +136,6 @@
     "kpno": {
         "aliases": [
             "Kitt Peak", 
-            "KPNO", 
             "Kitt Peak National Observatory"
         ], 
         "elevation_meters": 2120, 
@@ -160,7 +146,6 @@
     }, 
     "lapalma": {
         "aliases": [
-            "lapalma", 
             "Roque de los Muchachos"
         ], 
         "elevation_meters": 2327, 
@@ -171,7 +156,6 @@
     }, 
     "lco": {
         "aliases": [
-            "LCO", 
             "Las Campanas Observatory"
         ], 
         "elevation_meters": 2282, 
@@ -182,7 +166,6 @@
     }, 
     "lick": {
         "aliases": [
-            "Lick", 
             "Lick Observatory"
         ], 
         "elevation_meters": 1290, 
@@ -193,9 +176,8 @@
     }, 
     "lowell": {
         "aliases": [
-            "Lowell Observatory", 
-            "Lowell"
-        ], 
+            "Lowell Observatory"
+        ],
         "elevation_meters": 2198, 
         "latitude": "35d05m48s", 
         "longitude": "248d27m54s", 
@@ -204,8 +186,7 @@
     }, 
     "mcdonald": {
         "aliases": [
-            "McDonald Observatory", 
-            "mcdonald"
+            "McDonald Observatory"
         ], 
         "elevation_meters": 2075, 
         "latitude": "30d40m18.0001s", 
@@ -215,9 +196,8 @@
     }, 
     "mdm": {
         "aliases": [
-            "Michigan-Dartmouth-MIT Observatory", 
-            "MDM"
-        ], 
+            "Michigan-Dartmouth-MIT Observatory"
+        ],
         "elevation_meters": 1938, 
         "latitude": "31d57m00s", 
         "longitude": "248d23m00s", 
@@ -226,9 +206,8 @@
     }, 
     "mmt": {
         "aliases": [
-            "Multiple Mirror Telescope", 
-            "MMT"
-        ], 
+            "Multiple Mirror Telescope"
+        ],
         "elevation_meters": 2608, 
         "latitude": "31d41m18s", 
         "longitude": "249d06m54s", 
@@ -237,7 +216,6 @@
     }, 
     "mso": {
         "aliases": [
-            "MSO", 
             "Mt. Stromlo Observatory"
         ], 
         "elevation_meters": 767, 
@@ -248,7 +226,6 @@
     }, 
     "mtbigelow": {
         "aliases": [
-            "mtbigelow", 
             "Catalina Observatory"
         ], 
         "elevation_meters": 2510, 
@@ -259,9 +236,8 @@
     }, 
     "spm": {
         "aliases": [
-            "Observatorio Astronomico Nacional, San Pedro Martir", 
-            "SPM"
-        ], 
+            "Observatorio Astronomico Nacional, San Pedro Martir"
+        ],
         "elevation_meters": 2830, 
         "latitude": "31d01m45s", 
         "longitude": "244d30m47s", 
@@ -270,9 +246,8 @@
     }, 
     "sso": {
         "aliases": [
-            "Siding Spring Observatory", 
-            "sso"
-        ], 
+            "Siding Spring Observatory"
+        ],
         "elevation_meters": 1149, 
         "latitude": "-31d16m24.1s", 
         "longitude": "149d03m40.3s", 
@@ -281,7 +256,6 @@
     }, 
     "tona": {
         "aliases": [
-            "tona", 
             "Observatorio Astronomico Nacional, Tonantzintla"
         ], 
         "elevation_meters": 0, 
@@ -292,13 +266,22 @@
     }, 
     "vbo": {
         "aliases": [
-            "Vainu Bappu Observatory", 
-            "VBO"
-        ], 
+            "Vainu Bappu Observatory"
+        ],
         "elevation_meters": 725, 
         "latitude": "12d34m35.976s", 
         "longitude": "78d49m35.76s", 
         "name": "Vainu Bappu Observatory", 
         "source": "IRAF Observatory Database"
+    },
+    "Subaru": {
+        "aliases": [
+            "Subaru Telescope"
+        ],
+        "elevation_meters": 4139,
+        "latitude": "19d49m32s",
+        "longitude": "-155d28m34s",
+        "name": "Subaru",
+        "source": "Subaru Telescope website (August 2015)"
     }
 }

--- a/astroplan/sites.py
+++ b/astroplan/sites.py
@@ -159,6 +159,31 @@ def new_site_info_to_json(short_name, location, aliases, source):
     json_str : str
         String representation of the JSON-formatted observatory information
         for submissions to the astroplan observatories database via pull request
+
+    Example
+    -------
+    Make a new site for a telescope at the University of Washington
+    >>> from astropy.coordinates import EarthLocation
+    >>> from astroplan.sites import new_site_info_to_json
+    >>> import astropy.units as u
+    >>> location = EarthLocation.from_geodetic(-122.307703*u.deg, 47.653706*u.deg, 10*u.m)
+    >>> short_name = "My Fake Telescope"
+    >>> aliases = ["UW Drumheller Fountain Telescope"]
+    >>> source = "Brett Morris, personal communication"
+    >>> print(new_site_info_to_json(short_name, location, aliases, source)) # doctest: +SKIP
+    {
+        "My Fake Telescope": {
+            "aliases": [
+                "UW Drumheller Fountain Telescope"
+            ],
+            "elevation_meters": 9.999999999832553,
+            "latitude": "47d39m13.3416s",
+            "longitude": "-122d18m27.7308s",
+            "name": "My Fake Telescope",
+            "source": "Brett Morris, personal communication"
+        }
+    }
+
     """
     if _site_db is None:
         _load_sites()

--- a/astroplan/sites.py
+++ b/astroplan/sites.py
@@ -16,6 +16,7 @@ from astropy.utils.data import get_pkg_data_contents
 from difflib import get_close_matches
 import json
 from astropy.coordinates import EarthLocation
+import astropy.units as u
 
 __all__ = ['get_site', 'get_site_names', 'add_site']
 
@@ -35,6 +36,10 @@ def _load_sites():
                                    db[site]['latitude'],
                                    db[site]['elevation_meters'])
         _site_names.append(db[site]['name'])
+        _site_names.append(site)
+
+        _site_db[site.lower()] = location
+        _site_db[db[site]['name'].lower()] = location
         for alias in db[site]['aliases']:
             _site_db[alias.lower()] = location
 
@@ -119,3 +124,62 @@ def add_site(site_name, location):
         raise KeyError('The site "{}" already exists at (longitude,latitude,'
                        'elevation)={}'.format(site_name,
                                      _site_db[site_name.lower()].to_geodetic()))
+
+def new_site_info_to_json(short_name, location, aliases, source):
+    """
+    Generate JSON-formatted observatory information string.
+
+    Use this function to prepare new observatory submissions for the astroplan
+    observatory database. To submit the observatory for inclusion in the next
+    version of astroplan, post a pull request on the astroplan GitHub
+    repository [1]_. The json string should be put into the database in
+    `astroplan/data/observatories.json`.
+
+    .. [1] https://github.com/astroplanners/astroplan/pulls
+
+    Parameters
+    ----------
+    short_name : str
+        Short name of observatory
+
+    location : `~astropy.coordinates.EarthLocation`
+        Location of the observatory
+
+    elevation : `~astropy.units.Quantity`
+        Elevation of the observatory
+
+    aliases : list of strings
+        List of common abbreviations for the observatory name
+
+    source : str
+        Source of observatory information
+
+    Return
+    ------
+    json_str : str
+        String representation of the JSON-formatted observatory information
+        for submissions to the astroplan observatories database via pull request
+    """
+    if _site_db is None:
+        _load_sites()
+
+    # Gather all site names and aliases currently in database
+    all_site_names_and_aliases = _site_db.keys()
+
+    # Raise error if name/alias collision occurs
+    if short_name.lower() in all_site_names_and_aliases:
+        raise ValueError('short_name "{}" is already registered in the '
+                         'observatory database.'.format(short_name))
+    for alias in aliases:
+        if alias.lower() in all_site_names_and_aliases:
+            raise ValueError('alias {} is already registered in the '
+                             'observatory database.'.format(alias))
+
+    output_dict = {short_name :
+                        dict(name=short_name,
+                             longitude=location.longitude.to_string(unit=u.deg),
+                             latitude=location.latitude.to_string(unit=u.deg),
+                             elevation_meters=location.height.to(u.m).value,
+                             aliases=aliases,
+                             source=source)}
+    return json.dumps(output_dict, indent=4, sort_keys=True)

--- a/astroplan/tests/test_sites.py
+++ b/astroplan/tests/test_sites.py
@@ -7,7 +7,6 @@ from astropy.coordinates import Latitude, Longitude, EarthLocation
 import astropy.units as u
 import pytest
 import json
-from astropy.extern.six import string_types
 
 def test_get_site():
     # Compare to the IRAF observatory list available at:
@@ -81,8 +80,3 @@ def test_new_site_info_to_json():
     with pytest.raises(ValueError):
         # This name already exists
         new_site_info_to_json("Keck", location, aliases, source)
-
-class TestExceptions(unittest.TestCase):
-    def test_bad_site(self):
-        with self.assertRaises(KeyError):
-            get_site('nonexistent site')


### PR DESCRIPTION
Today @jberlanga asked me to add Subaru to the `data/observatories.json` database (just for you @ejeschke!). It made it clear to me that it would be much easier for users to create pull requests with their own observatories if they had a function that converts observatory properties to the appropriate JSON format, so I made a function that does that, and used it to create the Subaru entry. 

The new method is `new_site_info_to_json`, and can be called like this: 
```python
from astropy.coordinates import EarthLocation
from astroplan.sites import new_site_info_to_json

# New site for Subaru, information from
# http://subarutelescope.org/Observing/Telescope/Parameters/
location = EarthLocation.from_geodetic("-155d28m34s", "+19d49m32s", 4139*u.m)
short_name = "Subaru"
aliases = ["Subaru Telescope"]
source = "Subaru Telescope website (August 2015)"
print(new_site_info_to_json(short_name, location, aliases, source))
```
which prints
```json
{
    "Subaru": {
        "aliases": [
            "Subaru Telescope"
        ], 
        "elevation_meters": 4139.000000000389, 
        "latitude": "19d49m32s", 
        "longitude": "-155d28m34s", 
        "name": "Subaru", 
        "source": "Subaru Telescope website (August 2015)"
    }
}
```
This was then easy to copy and paste into the `observatories.json` file.

I also removed some redundant aliases from the `observatories.json` database.