### PR TITLE
Renaming twilight methods to include the prefix `twilight_*`

### DIFF
--- a/astroplan/core.py
+++ b/astroplan/core.py
@@ -962,7 +962,7 @@ class Observer(object):
 
     # Twilight convenience functions
 
-    def evening_astronomical(self, time, which='nearest'):
+    def twilight_evening_astronomical(self, time, which='nearest'):
         """
         Time at evening astronomical (-18 degree) twilight.
 
@@ -985,7 +985,7 @@ class Observer(object):
         """
         return self.sun_set_time(time, which, horizon=-18*u.degree)
 
-    def evening_nautical(self, time, which='nearest'):
+    def twilight_evening_nautical(self, time, which='nearest'):
 
         """
         Time at evening nautical (-12 degree) twilight.
@@ -1009,7 +1009,7 @@ class Observer(object):
         """
         return self.sun_set_time(time, which, horizon=-12*u.degree)
 
-    def evening_civil(self, time, which='nearest'):
+    def twilight_evening_civil(self, time, which='nearest'):
         """
         Time at evening civil (-6 degree) twilight.
 
@@ -1032,7 +1032,7 @@ class Observer(object):
         """
         return self.sun_set_time(time, which, horizon=-6*u.degree)
 
-    def morning_astronomical(self, time, which='nearest'):
+    def twilight_morning_astronomical(self, time, which='nearest'):
         """
         Time at morning astronomical (-18 degree) twilight.
 
@@ -1055,7 +1055,7 @@ class Observer(object):
         """
         return self.sun_rise_time(time, which, horizon=-18*u.degree)
 
-    def morning_nautical(self, time, which='nearest'):
+    def twilight_morning_nautical(self, time, which='nearest'):
         """
         Time at morning nautical (-12 degree) twilight.
 
@@ -1078,7 +1078,7 @@ class Observer(object):
         """
         return self.sun_rise_time(time, which, horizon=-12*u.degree)
 
-    def morning_civil(self, time, which='nearest'):
+    def twilight_morning_civil(self, time, which='nearest'):
         """
         Time at morning civil (-6 degree) twilight.
 

--- a/astroplan/tests/test_core.py
+++ b/astroplan/tests/test_core.py
@@ -450,16 +450,16 @@ def test_twilight_convenience_funcs():
     time = Time('2000-01-01 12:00:00')
     obs = Observer(location=location, pressure=pressure)
     # Compute morning twilights with astroplan
-    astroplan_morning_civil = obs.morning_civil(time, which='previous').datetime
-    astroplan_morning_nautical = obs.morning_nautical(time,
+    astroplan_morning_civil = obs.twilight_morning_civil(time, which='previous').datetime
+    astroplan_morning_nautical = obs.twilight_morning_nautical(time,
                                                       which='previous').datetime
-    astroplan_morning_astro = obs.morning_astronomical(time,
+    astroplan_morning_astro = obs.twilight_morning_astronomical(time,
                                                        which='previous').datetime
     # Compute evening twilights with astroplan
-    astroplan_evening_civil = obs.evening_civil(time, which='next').datetime
-    astroplan_evening_nautical = obs.evening_nautical(time,
+    astroplan_evening_civil = obs.twilight_evening_civil(time, which='next').datetime
+    astroplan_evening_nautical = obs.twilight_evening_nautical(time,
                                                       which='next').datetime
-    astroplan_evening_astro = obs.evening_astronomical(time,
+    astroplan_evening_astro = obs.twilight_evening_astronomical(time,
                                                        which='next').datetime
 
     # Compute morning and evening twilights with PyEphem from

--- a/dev/planning-example.py
+++ b/dev/planning-example.py
@@ -108,22 +108,22 @@ obs.moon_set(time_obs, which='nearest')
 obs.sun_set_time(time_obs, which='next', angle=18*u.degree)
 
 # evening (astronomical) twilight
-obs.evening_astronomical(time_obs)
+obs.twilight_evening_astronomical(time_obs)
 
 # evening (nautical) twilight
-obs.evening_nautical(time_obs)
+obs.twilight_evening_nautical(time_obs)
 
 # evening (civil) twilight
-obs.evening_civil(time_obs)
+obs.twilight_evening_civil(time_obs)
 
 # morning (nautical) twilight
-obs.morning_nautical(time_obs)
+obs.twilight_morning_nautical(time_obs)
 
 # morning (civil) twilight
-obs.morning_civil(time_obs)
+obs.twilight_morning_civil(time_obs)
 
 # morning (astronomical) twilight
-obs.morning_astronomical(time_obs)
+obs.twilight_morning_astronomical(time_obs)
 
 # what is the moon illumination?
 # returns a float, which is percentage of the moon illuminated


### PR DESCRIPTION
Since writing up the API, we've migrated towards maximally descriptive method names, and one area that has been neglected is the set of twilight convenience functions. I've used them while I have been observing this week, and I repeatedly forgot if we ordered the method name as `astronomical_evening` or `evening_astronomical`. I figured that if we prefixed all method names with `twilight_*`, tab completion would make the available methods obvious (did I hear @adrn shout for joy?) and save everyone some head scratching. 

This way: 
```
% ipython
In [1]: from astroplan import Observer
In [2]: apo = Observer.at_site("APO")
In [3]: apo.twi<TAB>
apo.twilight_evening_astronomical  apo.twilight_morning_astronomical
apo.twilight_evening_civil         apo.twilight_morning_civil
apo.twilight_evening_nautical      apo.twilight_morning_nautical
```